### PR TITLE
[SI-1802] Use normal open function instead of NamedTemporaryFile

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,8 @@
 from tempfile import NamedTemporaryFile
 
-from airflow.models import BaseOperator
 from airflow.hooks.mysql_hook import MySqlHook
 from airflow.hooks.S3_hook import S3Hook
+from airflow.models import BaseOperator
 from airflow.plugins_manager import AirflowPlugin
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
@@ -57,7 +57,7 @@ class S3ToMySqlLoadOperator(BaseOperator):
             raise RuntimeError('no file to process')
 
         with TemporaryDirectory(prefix='airflow_mysqlloadop_') as tmp_dir:
-            with NamedTemporaryFile('ab', dir=tmp_dir, delete=False) as tmp:
+            with open('{}/{}'.format(tmp_dir, 'numstats'), 'ab') as tmp:
                 for s3_infile in s3_infiles:
                     self.log.info('Download s3://%s/%s', self.s3_bucket, s3_infile)
 


### PR DESCRIPTION
As a title.

發現透過 `NamedTemporaryFile` 來下載的資料疑似只有一個檔案的量，
目前只要將 `NamedTemporaryFile` 改成一般的 `open` 就可以正常下載到完整資料。

下面是拿 staging 20210425134500 的資料測試：
- 用 NamedTemporaryFile 下載最後檔案的筆數是：4820
- 改用 open 下載最後檔案的比數是：219809
